### PR TITLE
Change lambdas to pointers in Option struct

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -81,15 +81,17 @@ struct Option {
   String label;
   std::function<void()> operation;
   bool selected = false;
-  std::function<void()> hover;
-  std::function<void()> render;
+  void ( *hover )();
+  void ( *render )(void *pointer);
+  void *pointer;
 
   Option(String lbl,
          const std::function<void()>& op,
          bool sel = false,
-         const std::function<void()>& hov = nullptr,
-         const std::function<void()>& ren = nullptr)
-    : label(lbl), operation(op), selected(sel), hover(hov), render(ren) {}
+         void ( *hov )() = nullptr,
+         void ( *ren )(void *pointer) = nullptr,
+         void *ptr = nullptr)
+    : label(lbl), operation(op), selected(sel), hover(hov), render(ren), pointer(ptr) {}
 };
 
 struct keyStroke { // DO NOT CHANGE IT!!!!!

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -425,8 +425,9 @@ int loopOptions(std::vector<Option>& options, bool submenu, const char *subText,
   while(1){
     handleSerialCommands();
     if (redraw) {
-      if (options[index].render) options[index].render();
-      else if(submenu) drawSubmenu(index, options, subText);
+      if (options[index].render) {
+        options[index].render(options[index].pointer);
+      } else if (submenu) drawSubmenu(index, options, subText);
       else coord=drawOptions(index, options, bruceConfig.priColor, bruceConfig.bgColor);
       if (options[index].hover) options[index].hover();
       redraw=false;

--- a/src/core/main_menu.cpp
+++ b/src/core/main_menu.cpp
@@ -38,8 +38,6 @@ MainMenu::~MainMenu() {}
 
 void MainMenu::begin(void) {
     options = {};
-    float scale = float((float)tftWidth / (float)240);
-    if (bruceConfig.rotation & 0b01) scale = float((float)tftHeight / (float)135);
 
     std::vector<String> l = bruceConfig.disabledMenus;
     for(int i = 0; i < _totalItems; i++) {
@@ -50,14 +48,18 @@ void MainMenu::begin(void) {
                 [=]() { _menuItems[i]->optionsMenu(); },
                 false, //selected = false
                 nullptr, // hover lambda
-                [=]() { // render lambda
+                [](void *menuItem) { // render lambda
                     drawMainBorder(false);
 
-                    _menuItems[i]->draw(scale);
+                    MenuItemInterface *obj = static_cast<MenuItemInterface *>(menuItem);
+                    float scale = float((float)tftWidth / (float)240);
+                    if (bruceConfig.rotation & 0b01) scale = float((float)tftHeight / (float)135);
+                    obj->draw(scale);
                     #if defined(HAS_TOUCH)
                     TouchFooter();
                     #endif
-                }
+                },
+                _menuItems[i]
             });
         }
     }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -111,11 +111,11 @@ void setBrightnessMenu() {
     else if (bruceConfig.bright == 1) idx = 4;
 
     options = {
-        {"100%", [=]() { setBrightness((uint8_t)99); },  bruceConfig.bright == 99, [=]()  { setBrightness((uint8_t)99, false);  }},
-        {"75 %", [=]() { setBrightness((uint8_t)75); },  bruceConfig.bright == 75 , [=]() { setBrightness((uint8_t)75, false);  }},
-        {"50 %", [=]() { setBrightness((uint8_t)50); },  bruceConfig.bright == 50, [=]()  { setBrightness((uint8_t)50, false);  }},
-        {"25 %", [=]() { setBrightness((uint8_t)25); },  bruceConfig.bright == 25, [=]()  { setBrightness((uint8_t)25, false);  }},
-        {" 1 %", [=]() { setBrightness((uint8_t)1); },   bruceConfig.bright == 1, [=]()   { setBrightness((uint8_t)1, false);   }}
+        {"100%", [=]() { setBrightness((uint8_t)99); },  bruceConfig.bright == 99, []()  { setBrightness((uint8_t)99, false);  }},
+        {"75 %", [=]() { setBrightness((uint8_t)75); },  bruceConfig.bright == 75 , []() { setBrightness((uint8_t)75, false);  }},
+        {"50 %", [=]() { setBrightness((uint8_t)50); },  bruceConfig.bright == 50, []()  { setBrightness((uint8_t)50, false);  }},
+        {"25 %", [=]() { setBrightness((uint8_t)25); },  bruceConfig.bright == 25, []()  { setBrightness((uint8_t)25, false);  }},
+        {" 1 %", [=]() { setBrightness((uint8_t)1); },   bruceConfig.bright == 1, []()   { setBrightness((uint8_t)1, false);   }}
     };
     addOptionToMainMenu(); // this one bugs the brightness selection
     int chosen = loopOptions(options, false, "", idx);


### PR DESCRIPTION
I think that the idea that logic for brightness and render can be moved to lambda function is good.
However this two lambdas add 44kB more to flash.

That lambdas can be changed into pointers, thanks to that we can save 37kB.
